### PR TITLE
Fixes to self-referential name instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <p align="center">
 </p>
 <h1 align="center">
-    <b>xKite: Kafka Integrated Testing Environment</b>
+    <b>xkite: Kafka Integrated Testing Environment</b>
     <br>
     <a href="https://xkite.io/">
         <img src="https://img.shields.io/twitter/url/http/shields.io.svg?style=social" />
@@ -13,7 +13,7 @@
 ![license](https://img.shields.io/badge/license-MIT-blue.svg)
 
 <p>
-    A comprehensive prototyping, testing, and monitoring toolset built for Apache Kafka. Use xKite to bootstrap your next project, or install our library into an existing project. Built by (and for) developers.
+    A comprehensive prototyping, testing, and monitoring toolset built for Apache Kafka. Use xkite to bootstrap your next project, or install our library into an existing project. Built by (and for) developers.
 </p>
 
 ---

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "xkite",
   "version": "1.0.0",
-  "title": "xKite: Kafka Integrated Testing Environment",
+  "title": "xkite: Kafka Integrated Testing Environment",
   "description": "A comprehensive prototyping, testing, and monitoring toolset built for Apache Kafka.",
-  "author": "XKite Team- OpenSource Labs",
+  "author": "xkite Team- OpenSource Labs",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -36,7 +36,7 @@ function xKiteApp(props: xKiteAppProps) {
   return (
     <CacheProvider value={emotionCache}>
       <Head>
-        <title>xKite: Kafka Integrated Testing Environment</title>
+        <title>xkite: Kafka Integrated Testing Environment</title>
         <meta
           name="viewport"
           content="width=device-width, initial-scale=1, shrink-to-fit=no"

--- a/pages/dockerMetrics/index.tsx
+++ b/pages/dockerMetrics/index.tsx
@@ -1,6 +1,6 @@
 import SidebarLayout from '@/layouts/SidebarLayout';
 import PageTitle from '@/components/PageTitle';
-import { useState, useEffect } from 'react';
+import { useState, useEffect, ReactChild, ReactFragment, ReactPortal } from 'react';
 import PageTitleWrapper from '@/components/PageTitleWrapper';
 import {
   Container,
@@ -172,6 +172,6 @@ function Forms() {
   );
 }
 
-Forms.getLayout = (page) => <SidebarLayout>{page}</SidebarLayout>;
+Forms.getLayout = (page: boolean | ReactChild | ReactFragment | ReactPortal) => <SidebarLayout>{page}</SidebarLayout>;
 
 export default Forms;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -33,7 +33,7 @@ function Overview() {
   return (
     <OverviewWrapper>
       <Head>
-        <title>xKite: A Kafka Prototyping, Testing, and Monitoring Suite</title>
+        <title>xkite: A Kafka Prototyping, Testing, and Monitoring Suite</title>
       </Head>
       <HeaderWrapper>
         <Container maxWidth="lg">

--- a/pages/status/500/index.tsx
+++ b/pages/status/500/index.tsx
@@ -117,14 +117,14 @@ function Status500() {
               <Container maxWidth="sm">
                 <Box textAlign="center">
                   <TypographyPrimary variant="h1" sx={{ my: 2 }}>
-                  xKite: Kafka Integrated Testing Environment
+                  xkite: Kafka Integrated Testing Environment
                   </TypographyPrimary>
                   <TypographySecondary
                     variant="h4"
                     fontWeight="normal"
                     sx={{ mb: 4 }}
                   >
-                    A comprehensive prototyping, testing, and monitoring toolset built for Apache Kafka. Use xKite to bootstrap your next project, or install our library into an existing project. Built by (and for) developers.
+                    A comprehensive prototyping, testing, and monitoring toolset built for Apache Kafka. Use xkite to bootstrap your next project, or install our library into an existing project. Built by (and for) developers.
                   </TypographySecondary>
                   <Button href="/" size="large" variant="contained">
                     Overview

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -4,7 +4,7 @@
   "display": "standalone",
   "start_url": ".",
   "short_name": "xKite",
-  "name": "xKite: Kafka Integrated Testing Environment",
+  "name": "xkite: Kafka Integrated Testing Environment",
   "icons": [
     {
       "src": "/icon-192x192.png",

--- a/src/components/LogoSign/index.tsx
+++ b/src/components/LogoSign/index.tsx
@@ -40,7 +40,7 @@ function Logo() {
 
   return (
     <TooltipWrapper
-      title="xKite: Kafka Integrated Testing Environment"
+      title="xkite: Kafka Integrated Testing Environment"
       arrow
     >
       <LogoWrapper href="/">

--- a/src/content/Overview/Hero/index.tsx
+++ b/src/content/Overview/Hero/index.tsx
@@ -53,7 +53,7 @@ function Hero() {
         <Grid item md={10} lg={8} mx="auto">
           <LabelWrapper color="success">Version 1.0.0</LabelWrapper>
           <TypographyH1 sx={{ mb: 2 }} variant="h1">
-            xKite: 
+            xkite: 
           </TypographyH1>
           <TypographyH12 sx={{ mb: 2 }} variant="h1">
             Kafka Integrated Testing Environment


### PR DESCRIPTION
Swapping out uppercase "K" for lowercase, and type assignment to module export in dockermetrics page